### PR TITLE
Add new hiding options and improve security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.1.0 (In Development)
+
+### Added
+
+- Settings Page
+
+### Improved
+
+- Hide all Comment-Options from Dashboard
+
 ## 1.0.0 (2024-02-27)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Improved
 
 - Hide all Comment-Options from Dashboard
+- Security
 
 ## 1.0.0 (2024-02-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0 (In Development)
+## 1.1.0 (2024-02-28)
 
 ### Added
 

--- a/inc/Silencer.php
+++ b/inc/Silencer.php
@@ -207,6 +207,17 @@ class Silencer {
 			return;
 		}
 
+		$this->process_form();
+
+		$this->display_form();
+	}
+
+	/**
+	 * Process form
+	 *
+	 * @return void
+	 */
+	private function process_form() {
 		if ( isset( $_POST['hide_settings'] ) ) {
 			if ( ! check_admin_referer( 'update-options' ) ) {
 				wp_die( 'Nonce verification failed' );
@@ -215,7 +226,14 @@ class Silencer {
 			$hide_settings = isset( $_POST['hide_settings'] ) ? 1 : 0;
 			update_option( 'hide_settings', $hide_settings );
 		}
+	}
 
+	/**
+	 * Display form
+	 *
+	 * @return void
+	 */
+	private function display_form() {
 		echo '<div class="wrap">';
 		echo '<h1>' . esc_html( get_admin_page_title() ) . '</h1>';
 		echo '<form method="post" action="options.php">';

--- a/inc/Silencer.php
+++ b/inc/Silencer.php
@@ -27,11 +27,20 @@ class Silencer {
 		add_filter( 'comments_open', [ $this, 'disable_comments_status' ], 20, 2 );
 		add_filter( 'pings_open', [ $this, 'disable_comments_status' ], 20, 2 );
 		add_filter( 'comments_array', [ $this, 'disable_comments_hide_existing_comments' ], 10, 2 );
-		add_action( 'admin_menu', [ $this, 'disable_comments_admin_menu' ] );
-		add_action( 'admin_init', [ $this, 'disable_comments_admin_menu_redirect' ] );
-		add_action( 'admin_init', [ $this, 'disable_comments_dashboard' ] );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'disable_comments_admin_bar' ] );
 		add_action( 'init', [ $this, 'disable_comments_on_media_attachments' ] );
+
+		$hide_settings = get_option( 'hide_settings' );
+
+		if ( '1' === $hide_settings ) {
+			add_action( 'admin_menu', [ $this, 'disable_comments_admin_menu' ] );
+			add_action( 'admin_init', [ $this, 'disable_comments_admin_menu_redirect' ] );
+			add_action( 'wp_dashboard_setup', [ $this, 'disable_comments_dashboard' ] );
+			add_action( 'admin_head', [ $this, 'hide_comments_from_activity_widget' ] );
+		}
+
+		add_action( 'admin_menu', [ $this, 'create_settings_page' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
 	}
 
 	/**
@@ -97,7 +106,7 @@ class Silencer {
 	 * @return void
 	 */
 	public function disable_comments_dashboard() {
-		remove_meta_box( 'dashboard_recent_comments', 'dashboard', 'normal' );
+		remove_meta_box( 'dashboard_recent_comments', 'dashboard', 'normal' ); // Recent Comments
 	}
 
 	/**
@@ -133,5 +142,71 @@ class Silencer {
 			10,
 			2
 		);
+	}
+
+
+	public function hide_comments_from_activity_widget() {
+		echo '
+		<style>
+		.comment-count, #latest-comments {
+			display: none;
+		}
+
+		#published-posts {
+			border-bottom: none;
+		}
+		</style>
+		';
+	}
+
+	public function create_settings_page() {
+		add_submenu_page(
+			'options-general.php',
+			'Silencer Options',
+			'Silencer',
+			'manage_options',
+			'silencer-options',
+			array( $this, 'silencer_options_page' )
+		);
+	}
+
+	public function register_settings() {
+		register_setting(
+			'silencer-settings-group',
+			'hide_settings',
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+				'default'           => 'none',
+			)
+		);
+	}
+
+	public function silencer_options_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html( get_admin_page_title() ) . '</h1>';
+		echo '<form method="post" action="options.php">';
+
+		settings_fields( 'silencer-settings-group' );
+
+		do_settings_sections( 'silencer-options' );
+
+		$hide_settings = get_option( 'hide_settings' );
+
+		echo '<table class="form-table">';
+		echo '<tr valign="top">';
+		echo '<th scope="row">Hide Comment Options</th>';
+		echo '<td><input type="checkbox" id="hide_settings" name="hide_settings" value="1" ' . checked( 1, $hide_settings, false ) . ' /></td>';
+		echo '</tr>';
+		echo '</table>';
+
+		submit_button( 'Save Settings' );
+
+		echo '</form>';
+		echo '</div>';
 	}
 }

--- a/inc/Silencer.php
+++ b/inc/Silencer.php
@@ -29,6 +29,7 @@ class Silencer {
 		add_filter( 'comments_array', [ $this, 'disable_comments_hide_existing_comments' ], 10, 2 );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'disable_comments_admin_bar' ] );
 		add_action( 'init', [ $this, 'disable_comments_on_media_attachments' ] );
+		add_action( 'admin_init', 'send_frame_options_header', 10, 0 );
 
 		$hide_settings = get_option( 'hide_settings' );
 
@@ -206,9 +207,19 @@ class Silencer {
 			return;
 		}
 
+		if ( isset( $_POST['hide_settings'] ) ) {
+			if ( ! check_admin_referer( 'update-options' ) ) {
+				wp_die( 'Nonce verification failed' );
+			}
+
+			$hide_settings = isset( $_POST['hide_settings'] ) ? 1 : 0;
+			update_option( 'hide_settings', $hide_settings );
+		}
+
 		echo '<div class="wrap">';
 		echo '<h1>' . esc_html( get_admin_page_title() ) . '</h1>';
 		echo '<form method="post" action="options.php">';
+		wp_nonce_field( 'update-options' );
 
 		settings_fields( 'silencer-settings-group' );
 

--- a/inc/Silencer.php
+++ b/inc/Silencer.php
@@ -144,7 +144,11 @@ class Silencer {
 		);
 	}
 
-
+	/**
+	 * Hide comments options from dashboard
+	 *
+	 * @return void
+	 */
 	public function hide_comments_from_activity_widget() {
 		echo '
 		<style>
@@ -159,6 +163,11 @@ class Silencer {
 		';
 	}
 
+	/**
+	 * Register settings page
+	 *
+	 * @return void
+	 */
 	public function create_settings_page() {
 		add_submenu_page(
 			'options-general.php',
@@ -170,6 +179,11 @@ class Silencer {
 		);
 	}
 
+	/**
+	 * Register settings
+	 *
+	 * @return void
+	 */
 	public function register_settings() {
 		register_setting(
 			'silencer-settings-group',
@@ -182,6 +196,11 @@ class Silencer {
 		);
 	}
 
+	/**
+	 * Create settings page
+	 *
+	 * @return void
+	 */
 	public function silencer_options_page() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;


### PR DESCRIPTION
This pull request adds new hiding options to the settings page and improves security by adding WP security functions. It also refactors the silencer_options_page into several functions and updates the changelog.