### PR TITLE
Fix block removal and enqueue from Plugins and Themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.1 (2024-07-26)
+
+### Fixed
+
+- Moved the block removal to `wp.blocks.unregisterBlockType` for better handling
+
 ## 1.2.0 (2024-06-20)
 
 ### Added

--- a/assets/dist/js/app.js
+++ b/assets/dist/js/app.js
@@ -1,1 +1,1 @@
-"use strict";(()=>{})();
+"use strict";(()=>{document.addEventListener("DOMContentLoaded",()=>{["core/comments","core/comment-title","core/comment-template","core/comment-name","core/comment-date","core/comment-content","core/comment-reply-link","core/comment-edit-link","core/comments-pagination","core/comments-pagination-next","core/comments-pagination-previous","core/comments-pagination-numbers","core/post-comments-form","core/post-comments-count","core/post-comments-link","core/latest-comments"].forEach(e=>{wp.blocks.unregisterBlockType(e)})});})();

--- a/assets/src/scripts/app.ts
+++ b/assets/src/scripts/app.ts
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const disallowedBlocks = [
+        'core/comments',
+        'core/comment-title',
+        'core/comment-template',
+        'core/comment-name',
+        'core/comment-date',
+        'core/comment-content',
+        'core/comment-reply-link',
+        'core/comment-edit-link',
+        'core/comments-pagination',
+        'core/comments-pagination-next',
+        'core/comments-pagination-previous',
+        'core/comments-pagination-numbers',
+        'core/post-comments-form',
+        'core/post-comments-count',
+        'core/post-comments-link',
+        'core/latest-comments',
+    ];
+
+    disallowedBlocks.forEach((block) => {
+        // @ts-expect-error: We need to use the `wp` global object to access the block editor.
+        wp.blocks.unregisterBlockType(block);
+    });
+});

--- a/inc/Silencer.php
+++ b/inc/Silencer.php
@@ -23,7 +23,7 @@ class Silencer {
 	 * @return void
 	 */
 	public function register() {
-		add_filter( 'allowed_block_types_all', [ $this, 'remove_comment_blocks' ], 10, 2 );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_link_block' ] );
 
 		add_action( 'admin_init', [ $this, 'disable_comments_post_types_support' ] );
 		add_filter( 'comments_open', [ $this, 'disable_comments_status' ], 20, 2 );
@@ -48,41 +48,14 @@ class Silencer {
 	}
 
 	/**
-	 * Allowed block types callback
+	 * Enqueue block scripts
 	 *
-	 * @param bool|array              $allowed_block_types The allowed block types.
-	 * @param WP_Block_Editor_Context $editor_context The current block editor context.
-	 * @return array The filtered block types.
+	 * @return void
 	 */
-	public function remove_comment_blocks( $allowed_block_types, $editor_context ) {
-		if ( ! empty( $editor_context ) ) {
-			$disallowed_blocks = array(
-				'core/comments',
-				'core/comment-title',
-				'core/comment-template',
-				'core/comment-name',
-				'core/comment-date',
-				'core/comment-content',
-				'core/comment-reply-link',
-				'core/comment-edit-link',
-				'core/comments-pagination',
-				'core/comments-pagination-next',
-				'core/comments-pagination-previous',
-				'core/comments-pagination-numbers',
-				'core/post-comments-form',
-				'core/post-comments-count',
-				'core/post-comments-link',
-				'core/latest-comments',
-			);
-		}
+	public function enqueue_link_block() {
+		$base_script_url = plugin_dir_url( __DIR__ ) . 'assets/dist/js/';
 
-		$allowed_block_types = \WP_Block_Type_Registry::get_instance()->get_all_registered();
-
-		foreach ( $disallowed_blocks as $block ) {
-			unset( $allowed_block_types[ $block ] );
-		}
-
-		return array_keys( $allowed_block_types );
+		wp_enqueue_script( 'silencer-script', $base_script_url . 'app.js', [ 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ], SILENCER_VERSION, true );
 	}
 
 	/**
@@ -206,7 +179,7 @@ class Silencer {
 	}
 
 	public function enqueue_admin_styles() {
-		wp_enqueue_style( 'silencer-style', plugin_dir_url( __DIR__ ) . 'assets/dist/css/style.css', [], '1.0.0' );
+		wp_enqueue_style( 'silencer-style', plugin_dir_url( __DIR__ ) . 'assets/dist/css/style.css', [], SILENCER_VERSION );
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,30 +82,30 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-            "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
+            "version": "7.24.9",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
+            "integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-            "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+            "version": "7.24.9",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
+            "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.7",
-                "@babel/helper-compilation-targets": "^7.24.7",
-                "@babel/helper-module-transforms": "^7.24.7",
-                "@babel/helpers": "^7.24.7",
-                "@babel/parser": "^7.24.7",
+                "@babel/generator": "^7.24.9",
+                "@babel/helper-compilation-targets": "^7.24.8",
+                "@babel/helper-module-transforms": "^7.24.9",
+                "@babel/helpers": "^7.24.8",
+                "@babel/parser": "^7.24.8",
                 "@babel/template": "^7.24.7",
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7",
+                "@babel/traverse": "^7.24.8",
+                "@babel/types": "^7.24.9",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -121,9 +121,9 @@
             }
         },
         "node_modules/@babel/eslint-parser": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.7.tgz",
-            "integrity": "sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.8.tgz",
+            "integrity": "sha512-nYAikI4XTGokU2QX7Jx+v4rxZKhKivaQaREZjuW3mrJrbdWJ5yUfohnoUULge+zEEaKjPYNxhoRgUKktjXtbwA==",
             "dev": true,
             "dependencies": {
                 "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -148,12 +148,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+            "version": "7.24.10",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
+            "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.7",
+                "@babel/types": "^7.24.9",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -188,14 +188,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-            "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
+            "integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.24.7",
-                "@babel/helper-validator-option": "^7.24.7",
-                "browserslist": "^4.22.2",
+                "@babel/compat-data": "^7.24.8",
+                "@babel/helper-validator-option": "^7.24.8",
+                "browserslist": "^4.23.1",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
@@ -204,15 +204,15 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.7.tgz",
-            "integrity": "sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.8.tgz",
+            "integrity": "sha512-4f6Oqnmyp2PP3olgUMmOwC3akxSm5aBYraQ6YDdKy7NcAMkDECHWG0DEnV6M2UAkERgIBhYt8S27rURPg7SxWA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.24.7",
                 "@babel/helper-environment-visitor": "^7.24.7",
                 "@babel/helper-function-name": "^7.24.7",
-                "@babel/helper-member-expression-to-functions": "^7.24.7",
+                "@babel/helper-member-expression-to-functions": "^7.24.8",
                 "@babel/helper-optimise-call-expression": "^7.24.7",
                 "@babel/helper-replace-supers": "^7.24.7",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
@@ -297,13 +297,13 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.7.tgz",
-            "integrity": "sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+            "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
             "dev": true,
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.24.8",
+                "@babel/types": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -323,9 +323,9 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-            "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+            "version": "7.24.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
+            "integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.24.7",
@@ -354,9 +354,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-            "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+            "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -435,9 +435,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+            "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -453,9 +453,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-            "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+            "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -477,13 +477,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-            "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
+            "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -505,9 +505,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+            "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -983,16 +983,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.7.tgz",
-            "integrity": "sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.8.tgz",
+            "integrity": "sha512-VXy91c47uujj758ud9wx+OMgheXm4qJfyhj1P18YvlrQkNOSrwsteHk+EFS3OMGfhMhpZa0A+81eE7G4QC+3CA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-compilation-targets": "^7.24.8",
                 "@babel/helper-environment-visitor": "^7.24.7",
                 "@babel/helper-function-name": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/helper-replace-supers": "^7.24.7",
                 "@babel/helper-split-export-declaration": "^7.24.7",
                 "globals": "^11.1.0"
@@ -1021,12 +1021,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.7.tgz",
-            "integrity": "sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.8.tgz",
+            "integrity": "sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1226,13 +1226,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.7.tgz",
-            "integrity": "sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
+            "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-module-transforms": "^7.24.8",
+                "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/helper-simple-access": "^7.24.7"
             },
             "engines": {
@@ -1390,12 +1390,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.7.tgz",
-            "integrity": "sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz",
+            "integrity": "sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             },
@@ -1602,12 +1602,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.7.tgz",
-            "integrity": "sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.8.tgz",
+            "integrity": "sha512-adNTUpDCVnmAE58VEqKlAA6ZBlNkMnWD0ZcW76lyNFN3MJniyGFZfNwERVk8Ap56MCnXztmDr19T4mPTztcuaw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1617,14 +1617,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.7.tgz",
-            "integrity": "sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.8.tgz",
+            "integrity": "sha512-CgFgtN61BbdOGCP4fLaAMOPkzWUh6yQZNMr5YSt8uz2cZSSiQONCQFWqsE4NeVfOIhqDOlS9CR3WD91FzMeB2Q==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-create-class-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-create-class-features-plugin": "^7.24.8",
+                "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/plugin-syntax-typescript": "^7.24.7"
             },
             "engines": {
@@ -1698,15 +1698,15 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.7.tgz",
-            "integrity": "sha512-1YZNsc+y6cTvWlDHidMBsQZrZfEFjRIo/BZCT906PMdzOyXtSLTgqGdrpcuTDCXyd11Am5uQULtDIcCfnTc8fQ==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.8.tgz",
+            "integrity": "sha512-vObvMZB6hNWuDxhSaEPTKCwcqkAIuDtE+bQGn4XMXne1DSLzFVY8Vmj1bm+mUQXYNN8NmaQEO+r8MMbzPr1jBQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.24.7",
-                "@babel/helper-compilation-targets": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-validator-option": "^7.24.7",
+                "@babel/compat-data": "^7.24.8",
+                "@babel/helper-compilation-targets": "^7.24.8",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-validator-option": "^7.24.8",
                 "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.7",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.7",
                 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
@@ -1737,9 +1737,9 @@
                 "@babel/plugin-transform-block-scoping": "^7.24.7",
                 "@babel/plugin-transform-class-properties": "^7.24.7",
                 "@babel/plugin-transform-class-static-block": "^7.24.7",
-                "@babel/plugin-transform-classes": "^7.24.7",
+                "@babel/plugin-transform-classes": "^7.24.8",
                 "@babel/plugin-transform-computed-properties": "^7.24.7",
-                "@babel/plugin-transform-destructuring": "^7.24.7",
+                "@babel/plugin-transform-destructuring": "^7.24.8",
                 "@babel/plugin-transform-dotall-regex": "^7.24.7",
                 "@babel/plugin-transform-duplicate-keys": "^7.24.7",
                 "@babel/plugin-transform-dynamic-import": "^7.24.7",
@@ -1752,7 +1752,7 @@
                 "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
                 "@babel/plugin-transform-member-expression-literals": "^7.24.7",
                 "@babel/plugin-transform-modules-amd": "^7.24.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.24.8",
                 "@babel/plugin-transform-modules-systemjs": "^7.24.7",
                 "@babel/plugin-transform-modules-umd": "^7.24.7",
                 "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
@@ -1762,7 +1762,7 @@
                 "@babel/plugin-transform-object-rest-spread": "^7.24.7",
                 "@babel/plugin-transform-object-super": "^7.24.7",
                 "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-                "@babel/plugin-transform-optional-chaining": "^7.24.7",
+                "@babel/plugin-transform-optional-chaining": "^7.24.8",
                 "@babel/plugin-transform-parameters": "^7.24.7",
                 "@babel/plugin-transform-private-methods": "^7.24.7",
                 "@babel/plugin-transform-private-property-in-object": "^7.24.7",
@@ -1773,7 +1773,7 @@
                 "@babel/plugin-transform-spread": "^7.24.7",
                 "@babel/plugin-transform-sticky-regex": "^7.24.7",
                 "@babel/plugin-transform-template-literals": "^7.24.7",
-                "@babel/plugin-transform-typeof-symbol": "^7.24.7",
+                "@babel/plugin-transform-typeof-symbol": "^7.24.8",
                 "@babel/plugin-transform-unicode-escapes": "^7.24.7",
                 "@babel/plugin-transform-unicode-property-regex": "^7.24.7",
                 "@babel/plugin-transform-unicode-regex": "^7.24.7",
@@ -1782,7 +1782,7 @@
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
                 "babel-plugin-polyfill-corejs3": "^0.10.4",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "core-js-compat": "^3.31.0",
+                "core-js-compat": "^3.37.1",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1832,9 +1832,9 @@
             "dev": true
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-            "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+            "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -1858,19 +1858,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-            "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
+            "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.7",
+                "@babel/generator": "^7.24.8",
                 "@babel/helper-environment-visitor": "^7.24.7",
                 "@babel/helper-function-name": "^7.24.7",
                 "@babel/helper-hoist-variables": "^7.24.7",
                 "@babel/helper-split-export-declaration": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/types": "^7.24.7",
+                "@babel/parser": "^7.24.8",
+                "@babel/types": "^7.24.8",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -1879,12 +1879,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+            "version": "7.24.9",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
+            "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-string-parser": "^7.24.8",
                 "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
@@ -2043,9 +2043,9 @@
             }
         },
         "node_modules/@commitlint/is-ignored/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -2249,9 +2249,9 @@
             }
         },
         "node_modules/@csstools/css-parser-algorithms": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.3.tgz",
-            "integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.7.1.tgz",
+            "integrity": "sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw==",
             "dev": true,
             "funding": [
                 {
@@ -2267,13 +2267,13 @@
                 "node": "^14 || ^16 || >=18"
             },
             "peerDependencies": {
-                "@csstools/css-tokenizer": "^2.3.1"
+                "@csstools/css-tokenizer": "^2.4.1"
             }
         },
         "node_modules/@csstools/css-tokenizer": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.3.1.tgz",
-            "integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.4.1.tgz",
+            "integrity": "sha512-eQ9DIktFJBhGjioABJRtUucoWR2mwllurfnM8LuNGAqX3ViZXaUchqk+1s7jjtkFiT9ySdACsFEA3etErkALUg==",
             "dev": true,
             "funding": [
                 {
@@ -2290,9 +2290,9 @@
             }
         },
         "node_modules/@csstools/media-query-list-parser": {
-            "version": "2.1.11",
-            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.11.tgz",
-            "integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
+            "version": "2.1.13",
+            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.13.tgz",
+            "integrity": "sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA==",
             "dev": true,
             "funding": [
                 {
@@ -2308,8 +2308,8 @@
                 "node": "^14 || ^16 || >=18"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^2.6.3",
-                "@csstools/css-tokenizer": "^2.3.1"
+                "@csstools/css-parser-algorithms": "^2.7.1",
+                "@csstools/css-tokenizer": "^2.4.1"
             }
         },
         "node_modules/@csstools/selector-specificity": {
@@ -2742,9 +2742,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
-            "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+            "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -2911,9 +2911,9 @@
             "dev": true
         },
         "node_modules/@inquirer/figures": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.3.tgz",
-            "integrity": "sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.5.tgz",
+            "integrity": "sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==",
             "dev": true,
             "engines": {
                 "node": ">=18"
@@ -3832,9 +3832,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -3845,18 +3845,6 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "node_modules/@ljharb/through": {
-            "version": "2.3.13",
-            "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
-            "integrity": "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -4022,9 +4010,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.56.10",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-            "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
+            "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -4117,9 +4105,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.14.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.6.tgz",
-            "integrity": "sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw==",
+            "version": "20.14.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+            "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -4200,9 +4188,9 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -4325,9 +4313,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -4362,9 +4350,9 @@
             }
         },
         "node_modules/@typescript-eslint/utils/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -4742,9 +4730,9 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-            "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+            "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -4820,15 +4808,15 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-            "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
                 "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.4.1"
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
@@ -5034,18 +5022,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/array.prototype.toreversed": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
-            "integrity": "sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "es-shim-unscopables": "^1.0.0"
-            }
-        },
         "node_modules/array.prototype.tosorted": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
@@ -5098,6 +5074,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/async": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+            "dev": true
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -5441,9 +5423,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.23.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+            "version": "4.23.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
+            "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
             "dev": true,
             "funding": [
                 {
@@ -5460,10 +5442,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001629",
-                "electron-to-chromium": "^1.4.796",
+                "caniuse-lite": "^1.0.30001640",
+                "electron-to-chromium": "^1.4.820",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.16"
+                "update-browserslist-db": "^1.1.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -5545,9 +5527,9 @@
             }
         },
         "node_modules/builtins/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -5603,9 +5585,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001636",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
-            "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
+            "version": "1.0.30001643",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
+            "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==",
             "dev": true,
             "funding": [
                 {
@@ -6734,10 +6716,25 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true
         },
+        "node_modules/ejs": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+            "dev": true,
+            "dependencies": {
+                "jake": "^10.8.5"
+            },
+            "bin": {
+                "ejs": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.807",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.807.tgz",
-            "integrity": "sha512-kSmJl2ZwhNf/bcIuCH/imtNOKlpkLDn2jqT5FJ+/0CXjhnFaOa9cOe9gHKKy71eM49izwuQjZhKk+lWQ1JxB7A==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.2.tgz",
+            "integrity": "sha512-kc4r3U3V3WLaaZqThjYz/Y6z8tJe+7K0bbjUVo3i+LWIypVdMx5nXCkwRe6SWbY6ILqLdc1rKcKmr3HoH7wjSQ==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -6768,9 +6765,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.17.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-            "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+            "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -6937,9 +6934,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-            "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+            "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
             "dev": true,
             "peer": true
         },
@@ -7189,9 +7186,9 @@
             }
         },
         "node_modules/eslint-compat-utils/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -7313,9 +7310,9 @@
             }
         },
         "node_modules/eslint-plugin-es-x": {
-            "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.7.0.tgz",
-            "integrity": "sha512-aP3qj8BwiEDPttxQkZdI221DLKq9sI/qHolE2YSQL1/9+xk7dTV+tB1Fz8/IaCA+lnLA1bDEnvaS2LKs0k2Uig==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+            "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/ota-meshi",
@@ -7323,7 +7320,7 @@
             ],
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.1.2",
-                "@eslint-community/regexpp": "^4.6.0",
+                "@eslint-community/regexpp": "^4.11.0",
                 "eslint-compat-utils": "^0.5.1"
             },
             "engines": {
@@ -7533,9 +7530,9 @@
             }
         },
         "node_modules/eslint-plugin-jest/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -7580,9 +7577,9 @@
             }
         },
         "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -7709,9 +7706,9 @@
             }
         },
         "node_modules/eslint-plugin-n/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -7748,13 +7745,13 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
-            "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+            "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
             "dev": true,
             "dependencies": {
                 "prettier-linter-helpers": "^1.0.0",
-                "synckit": "^0.8.6"
+                "synckit": "^0.9.1"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -7778,9 +7775,9 @@
             }
         },
         "node_modules/eslint-plugin-promise": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.2.0.tgz",
-            "integrity": "sha512-QmAqwizauvnKOlifxyDj2ObfULpHQawlg/zQdgEixur9vl0CvZGv/LCJV2rtj3210QCoeGBzVMfMXqGAOr/4fA==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
+            "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7793,35 +7790,35 @@
             }
         },
         "node_modules/eslint-plugin-react": {
-            "version": "7.34.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.3.tgz",
-            "integrity": "sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==",
+            "version": "7.35.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz",
+            "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
             "dev": true,
             "dependencies": {
                 "array-includes": "^3.1.8",
                 "array.prototype.findlast": "^1.2.5",
                 "array.prototype.flatmap": "^1.3.2",
-                "array.prototype.toreversed": "^1.1.2",
                 "array.prototype.tosorted": "^1.1.4",
                 "doctrine": "^2.1.0",
                 "es-iterator-helpers": "^1.0.19",
                 "estraverse": "^5.3.0",
+                "hasown": "^2.0.2",
                 "jsx-ast-utils": "^2.4.1 || ^3.0.0",
                 "minimatch": "^3.1.2",
                 "object.entries": "^1.1.8",
                 "object.fromentries": "^2.0.8",
-                "object.hasown": "^1.1.4",
                 "object.values": "^1.2.0",
                 "prop-types": "^15.8.1",
                 "resolve": "^2.0.0-next.5",
                 "semver": "^6.3.1",
-                "string.prototype.matchall": "^4.0.11"
+                "string.prototype.matchall": "^4.0.11",
+                "string.prototype.repeat": "^1.0.0"
             },
             "engines": {
                 "node": ">=4"
             },
             "peerDependencies": {
-                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
             }
         },
         "node_modules/eslint-plugin-react-hooks": {
@@ -8188,9 +8185,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -8365,6 +8362,12 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-uri": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+            "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+            "dev": true
+        },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -8417,6 +8420,27 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "node_modules/filelist": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+            "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+            "dev": true,
+            "dependencies": {
+                "minimatch": "^5.0.1"
+            }
+        },
+        "node_modules/filelist/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/fill-range": {
@@ -8682,9 +8706,9 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.7.5",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
-            "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
+            "version": "4.7.6",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.6.tgz",
+            "integrity": "sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==",
             "dev": true,
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -8711,9 +8735,9 @@
             }
         },
         "node_modules/glob": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
-            "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dev": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
@@ -8725,9 +8749,6 @@
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -8752,9 +8773,9 @@
             "peer": true
         },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -9041,9 +9062,9 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.0.2",
@@ -9063,12 +9084,12 @@
             }
         },
         "node_modules/husky": {
-            "version": "9.0.11",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-            "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.2.tgz",
+            "integrity": "sha512-1/aDMXZdhr1VdJJTLt6e7BipM0Jd9qkpubPiIplon1WmCeOy3nnzsCMeBqS9AsL5ioonl8F8y/F2CLOmk19/Pw==",
             "dev": true,
             "bin": {
-                "husky": "bin.mjs"
+                "husky": "bin.js"
             },
             "engines": {
                 "node": ">=18"
@@ -9119,9 +9140,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-            "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+            "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
             "dev": true
         },
         "node_modules/import-fresh": {
@@ -9150,9 +9171,9 @@
             }
         },
         "node_modules/import-local": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-            "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+            "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
             "dev": true,
             "dependencies": {
                 "pkg-dir": "^4.2.0",
@@ -9214,41 +9235,26 @@
             }
         },
         "node_modules/inquirer": {
-            "version": "9.2.23",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.23.tgz",
-            "integrity": "sha512-kod5s+FBPIDM2xiy9fu+6wdU/SkK5le5GS9lh4FEBjBHqiMgD9lLFbCbuqFNAjNL2ZOy9Wd9F694IOzN9pZHBA==",
+            "version": "9.3.6",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.6.tgz",
+            "integrity": "sha512-riK/iQB2ctwkpWYgjjWIRv3MBLt2gzb2Sj0JNQNbyTXgyXsLWcDPJ5WS5ZDTCx7BRFnJsARtYh+58fjP5M2Y0Q==",
             "dev": true,
             "dependencies": {
                 "@inquirer/figures": "^1.0.3",
-                "@ljharb/through": "^2.3.13",
                 "ansi-escapes": "^4.3.2",
-                "chalk": "^5.3.0",
-                "cli-cursor": "^3.1.0",
                 "cli-width": "^4.1.0",
                 "external-editor": "^3.1.0",
-                "lodash": "^4.17.21",
                 "mute-stream": "1.0.0",
                 "ora": "^5.4.1",
                 "run-async": "^3.0.0",
                 "rxjs": "^7.8.1",
                 "string-width": "^4.2.3",
                 "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^6.2.0"
+                "wrap-ansi": "^6.2.0",
+                "yoctocolors-cjs": "^2.1.2"
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/inquirer/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-            "dev": true,
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/internal-slot": {
@@ -9385,12 +9391,15 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
+            "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
             "dev": true,
             "dependencies": {
-                "hasown": "^2.0.0"
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9780,9 +9789,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
-            "integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+            "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.23.9",
@@ -9796,9 +9805,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -9883,21 +9892,128 @@
             }
         },
         "node_modules/jackspeak": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
-            "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             },
             "optionalDependencies": {
                 "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/jake": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+            "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+            "dev": true,
+            "dependencies": {
+                "async": "^3.2.3",
+                "chalk": "^4.0.2",
+                "filelist": "^1.0.4",
+                "minimatch": "^3.1.2"
+            },
+            "bin": {
+                "jake": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jake/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/jake/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/jake/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/jake/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/jake/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/jake/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jake/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/jake/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/jest": {
@@ -11571,9 +11687,9 @@
             }
         },
         "node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -11951,9 +12067,9 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "24.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.0.tgz",
-            "integrity": "sha512-6gpM7pRXCwIOKxX47cgOyvyQDN/Eh0f1MeKySBV2xGdKtqJBLj8P25eY3EVCWo2mglDDzozR2r2MW4T+JiNUZA==",
+            "version": "24.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.1.tgz",
+            "integrity": "sha512-5O1wWV99Jhq4DV7rCLIoZ/UIhyQeDR7wHVyZAHAshbrvZsLs+Xzz7gtwnlJTJDjleiTKh54F4dXrX70vJQTyJQ==",
             "dev": true,
             "dependencies": {
                 "cssstyle": "^4.0.1",
@@ -11962,11 +12078,11 @@
                 "form-data": "^4.0.0",
                 "html-encoding-sniffer": "^4.0.0",
                 "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.4",
+                "https-proxy-agent": "^7.0.5",
                 "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.10",
+                "nwsapi": "^2.2.12",
                 "parse5": "^7.1.2",
-                "rrweb-cssom": "^0.7.0",
+                "rrweb-cssom": "^0.7.1",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
                 "tough-cookie": "^4.1.4",
@@ -11975,7 +12091,7 @@
                 "whatwg-encoding": "^3.1.1",
                 "whatwg-mimetype": "^4.0.0",
                 "whatwg-url": "^14.0.0",
-                "ws": "^8.17.0",
+                "ws": "^8.18.0",
                 "xml-name-validator": "^5.0.0"
             },
             "engines": {
@@ -12127,9 +12243,9 @@
             }
         },
         "node_modules/known-css-properties": {
-            "version": "0.31.0",
-            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.31.0.tgz",
-            "integrity": "sha512-sBPIUGTNF0czz0mwGGUoKKJC8Q7On1GPbCSFPfyEsfHb2DyBG0Y4QtV+EVWpINSaiGKZblDNuF5AezxSgOhesQ==",
+            "version": "0.34.0",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
+            "integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==",
             "dev": true
         },
         "node_modules/language-subtag-registry": {
@@ -12438,9 +12554,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -12644,9 +12760,9 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -12691,9 +12807,9 @@
             }
         },
         "node_modules/nwsapi": {
-            "version": "2.2.10",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-            "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==",
+            "version": "2.2.12",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+            "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
             "dev": true
         },
         "node_modules/object-assign": {
@@ -12706,10 +12822,13 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
             "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -12801,23 +12920,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/object.hasown": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
-            "integrity": "sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==",
-            "dev": true,
-            "dependencies": {
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.2",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/object.values": {
@@ -13026,9 +13128,9 @@
             }
         },
         "node_modules/p-locate/node_modules/yocto-queue": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+            "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
             "dev": true,
             "engines": {
                 "node": ">=12.20"
@@ -13153,13 +13255,10 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-            "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
-            "dev": true,
-            "engines": {
-                "node": "14 || >=16.14"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -13285,9 +13384,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.38",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+            "version": "8.4.40",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
+            "integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
             "dev": true,
             "funding": [
                 {
@@ -13305,7 +13404,7 @@
             ],
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.0.1",
                 "source-map-js": "^1.2.0"
             },
             "engines": {
@@ -13319,9 +13418,9 @@
             "dev": true
         },
         "node_modules/postcss-resolve-nested-selector": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-            "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.4.tgz",
+            "integrity": "sha512-R6vHqZWgVnTAPq0C+xjyHfEZqfIYboCBVSy24MjxEDm+tIh1BU4O6o7DP7AA7kHzf136d+Qc5duI4tlpHjixDw==",
             "dev": true
         },
         "node_modules/postcss-safe-parser": {
@@ -13377,9 +13476,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
-            "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
+            "integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -13405,9 +13504,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-            "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -14058,9 +14157,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.77.6",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
-            "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
+            "version": "1.77.8",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+            "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -14537,6 +14636,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/string.prototype.repeat": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+            "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+            "dev": true,
+            "dependencies": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            }
+        },
         "node_modules/string.prototype.trim": {
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
@@ -14645,9 +14754,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.6.1.tgz",
-            "integrity": "sha512-yNgz2PqWLkhH2hw6X9AweV9YvoafbAD5ZsFdKN9BvSDVwGvPh+AUIrn7lYwy1S7IHmtFin75LLfX1m0D2tHu8Q==",
+            "version": "16.7.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.7.0.tgz",
+            "integrity": "sha512-Q1ATiXlz+wYr37a7TGsfvqYn2nSR3T/isw3IWlZQzFzCNoACHuGBb6xBplZXz56/uDRJHIygxjh7jbV/8isewA==",
             "dev": true,
             "funding": [
                 {
@@ -14660,9 +14769,9 @@
                 }
             ],
             "dependencies": {
-                "@csstools/css-parser-algorithms": "^2.6.3",
-                "@csstools/css-tokenizer": "^2.3.1",
-                "@csstools/media-query-list-parser": "^2.1.11",
+                "@csstools/css-parser-algorithms": "^2.7.1",
+                "@csstools/css-tokenizer": "^2.4.1",
+                "@csstools/media-query-list-parser": "^2.1.13",
                 "@csstools/selector-specificity": "^3.1.1",
                 "@dual-bundle/import-meta-resolve": "^4.1.0",
                 "balanced-match": "^2.0.0",
@@ -14670,7 +14779,7 @@
                 "cosmiconfig": "^9.0.0",
                 "css-functions-list": "^3.2.2",
                 "css-tree": "^2.3.1",
-                "debug": "^4.3.4",
+                "debug": "^4.3.5",
                 "fast-glob": "^3.3.2",
                 "fastest-levenshtein": "^1.0.16",
                 "file-entry-cache": "^9.0.0",
@@ -14681,13 +14790,13 @@
                 "ignore": "^5.3.1",
                 "imurmurhash": "^0.1.4",
                 "is-plain-object": "^5.0.0",
-                "known-css-properties": "^0.31.0",
+                "known-css-properties": "^0.34.0",
                 "mathml-tag-names": "^2.1.3",
                 "meow": "^13.2.0",
                 "micromatch": "^4.0.7",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.0.1",
-                "postcss": "^8.4.38",
+                "postcss": "^8.4.39",
                 "postcss-resolve-nested-selector": "^0.1.1",
                 "postcss-safe-parser": "^7.0.0",
                 "postcss-selector-parser": "^6.1.0",
@@ -14708,33 +14817,43 @@
             }
         },
         "node_modules/stylelint-config-recommended": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
-            "integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
+            "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/stylelint"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/stylelint"
+                }
+            ],
             "engines": {
                 "node": ">=18.12.0"
             },
             "peerDependencies": {
-                "stylelint": "^16.0.0"
+                "stylelint": "^16.1.0"
             }
         },
         "node_modules/stylelint-config-recommended-scss": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.0.0.tgz",
-            "integrity": "sha512-HDvpoOAQ1RpF+sPbDOT2Q2/YrBDEJDnUymmVmZ7mMCeNiFSdhRdyGEimBkz06wsN+HaFwUh249gDR+I9JR7Onw==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.1.0.tgz",
+            "integrity": "sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==",
             "dev": true,
             "dependencies": {
                 "postcss-scss": "^4.0.9",
-                "stylelint-config-recommended": "^14.0.0",
-                "stylelint-scss": "^6.0.0"
+                "stylelint-config-recommended": "^14.0.1",
+                "stylelint-scss": "^6.4.0"
             },
             "engines": {
                 "node": ">=18.12.0"
             },
             "peerDependencies": {
                 "postcss": "^8.3.3",
-                "stylelint": "^16.0.2"
+                "stylelint": "^16.6.1"
             },
             "peerDependenciesMeta": {
                 "postcss": {
@@ -14743,12 +14862,22 @@
             }
         },
         "node_modules/stylelint-config-standard": {
-            "version": "36.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.0.tgz",
-            "integrity": "sha512-3Kjyq4d62bYFp/Aq8PMKDwlgUyPU4nacXsjDLWJdNPRUgpuxALu1KnlAHIj36cdtxViVhXexZij65yM0uNIHug==",
+            "version": "36.0.1",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
+            "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/stylelint"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/stylelint"
+                }
+            ],
             "dependencies": {
-                "stylelint-config-recommended": "^14.0.0"
+                "stylelint-config-recommended": "^14.0.1"
             },
             "engines": {
                 "node": ">=18.12.0"
@@ -14780,12 +14909,12 @@
             }
         },
         "node_modules/stylelint-scss": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.3.2.tgz",
-            "integrity": "sha512-pNk9mXOVKkQtd+SROPC9io8ISSgX+tOVPhFdBE+LaKQnJMLdWPbGKAGYv4Wmf/RrnOjkutunNTN9kKMhkdE5qA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.4.1.tgz",
+            "integrity": "sha512-+clI2bQC2FPOt06ZwUlXZZ95IO2C5bKTP0GLN1LNQPVvISfSNcgMKv/VTwym1mK9vnqhHbOk8lO4rj4nY7L9pw==",
             "dev": true,
             "dependencies": {
-                "known-css-properties": "^0.31.0",
+                "known-css-properties": "^0.34.0",
                 "postcss-media-query-parser": "^0.2.3",
                 "postcss-resolve-nested-selector": "^0.1.1",
                 "postcss-selector-parser": "^6.1.0",
@@ -15015,9 +15144,9 @@
             "dev": true
         },
         "node_modules/synckit": {
-            "version": "0.8.8",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
-            "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+            "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
             "dev": true,
             "dependencies": {
                 "@pkgr/core": "^0.1.0",
@@ -15056,9 +15185,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.31.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
-            "integrity": "sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==",
+            "version": "5.31.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.3.tgz",
+            "integrity": "sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -15329,12 +15458,13 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.1.5",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
-            "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
+            "version": "29.2.3",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.3.tgz",
+            "integrity": "sha512-yCcfVdiBFngVz9/keHin9EnsrQtQtEu3nRykNy9RVp+FiPFFbPJ3Sg6Qg4+TkmH0vMP5qsTKgXSsk80HRwvdgQ==",
             "dev": true,
             "dependencies": {
                 "bs-logger": "0.x",
+                "ejs": "^3.1.10",
                 "fast-json-stable-stringify": "2.x",
                 "jest-util": "^29.0.0",
                 "json5": "^2.2.3",
@@ -15376,9 +15506,9 @@
             }
         },
         "node_modules/ts-jest/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -15554,9 +15684,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-            "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -15649,9 +15779,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-            "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
             "dev": true,
             "funding": [
                 {
@@ -15704,9 +15834,9 @@
             "dev": true
         },
         "node_modules/v8-to-istanbul": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-            "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
@@ -15771,9 +15901,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.92.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
-            "integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
+            "version": "5.93.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+            "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -16101,9 +16231,9 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -16194,6 +16324,18 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yoctocolors-cjs": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+            "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/utils-silencer.php
+++ b/utils-silencer.php
@@ -9,7 +9,7 @@
  * Plugin Name:   Silencer
  * Plugin URI:    https://github.com/Stutz-Medien/Silencer
  * Description:   Surpresses all comments on your WordPress site.
- * Version:       1.2.0
+ * Version:       1.2.1
  * Author:        Stutz Medien
  * Author URI:    https://stutz-medien.ch/
  * Text Domain:   acf
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+define( 'SILENCER_VERSION', '1.2.1' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) :
 	require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
This pull request fixes the issue where only default WordPress blocks were being enqueued and not blocks from Plugins or Themes. The issue was caused by the block removal process being done via PHP instead of TypeScript. The fix ensures that blocks are removed correctly and only the desired blocks are removed. Additionally, the block enqueue process has been updated to include blocks from Plugins and Themes.

Fixes #5